### PR TITLE
Use newer language features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ erl_crash.dump
 
 # And ignore test artifacts
 *.pid
+
+mix.lock

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,6 @@
 use Mix.Config
 
 config :pid_file, file: "./dev.pid"
+# config :pid_file, file: {:SYSTEM, "PIDFILE"}
 
 config :logger, level: :info

--- a/lib/pid_file/application.ex
+++ b/lib/pid_file/application.ex
@@ -10,15 +10,12 @@ defmodule PidFile.Application do
 
     worker =
       case Application.get_env(:pid_file, :file, nil) do
-        nil -> []
-        file when is_binary(file) -> [worker(PidFile.Worker, [[file: file]])]
+        nil ->
+          []
+        file when is_binary(file) ->
+          worker(file)
         {:SYSTEM, env_var} when is_binary(env_var) or is_list(env_var) ->
-          case :os.getenv(env_var, nil) do
-            nil -> throw "Missing Environment Variable:  #{env_var}"
-            "" ->  throw "Missing Environment Variable:  #{env_var}"
-            '' ->  throw "Missing Environment Variable:  #{env_var}"
-            file -> [worker(PidFile.Worker, [[file: file]])]
-          end
+          get_from_env(env_var)
       end
 
     children =
@@ -27,4 +24,29 @@ defmodule PidFile.Application do
     opts = [strategy: :one_for_one, name: PidFile.Supervisor]
     Supervisor.start_link(children, opts)
   end
+
+  if Version.match?(System.version(), ">= 1.9.0") do
+    defp get_from_env(env_var) do
+      case System.get_env(env_var) do
+        nil -> throw_env(env_var)
+        file -> worker(file)
+      end
+    end
+  else
+    defp get_from_env(env_var) do
+      case :os.getenv(env_var, nil) do
+        nil -> throw_env(env_var)
+        "" ->  throw_env(env_var)
+        '' ->  throw_env(env_var)
+        file -> worker(file)
+      end
+    end
+  end
+
+  defp throw_env(env_var) do
+    throw "Missing Environment Variable:  #{env_var}"
+  end
+
+  defp worker(file), do: [{PidFile.Worker, [file: file]}]
+
 end

--- a/lib/pid_file/worker.ex
+++ b/lib/pid_file/worker.ex
@@ -1,15 +1,16 @@
 defmodule PidFile.Worker do
-  @moduledoc """
-  """
+
+  @moduledoc false
 
   use GenServer
+
   require Logger
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, [name: opts[:name]])
   end
 
-
+  @impl true
   def init(opts) do
     Process.flag(:trap_exit, true)
     file =
@@ -23,28 +24,24 @@ defmodule PidFile.Worker do
     {:ok, file}
   end
 
-
+  @impl true
   def terminate(reason, file) do
     cleanup_pid(file)
     reason
   end
 
-
-  defp get_pid() do
-    :os.getpid() # charlist
-    |> to_string()
-    |> String.to_integer()
+  if Version.match?(System.version(), ">= 1.9.0") do
+    defp get_pid(), do: System.pid()
+  else
+    defp get_pid(), do: to_string(:os.getpid())
   end
 
-
   defp update_pid(file) do
-    pid =
-      get_pid()
-      |> to_string()
-    File.write!(file, pid, [:write, :binary])
+    File.write!(file, get_pid(), [:write, :binary])
   end
 
   defp cleanup_pid(file) do
     File.rm(file)
   end
+
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,0 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/test/pid_file_test.exs
+++ b/test/pid_file_test.exs
@@ -1,10 +1,15 @@
 defmodule PidFileTest do
+
   use ExUnit.Case
   doctest PidFile
 
   test "PIDfile gets created and destroyed" do
-    {:ok, pid} = PidFile.Worker.start_link(file: "./test1.pid")
+    file = "./test1.pid"
+    {:ok, pid} = PidFile.Worker.start_link(file: file)
+    assert File.exists?(file)
     Process.sleep(4000)
     GenServer.stop(pid)
+    refute File.exists?(file)
   end
+
 end


### PR DESCRIPTION
Optionally use some newer language features, and change the application
to use the newer supervisor spec and avoid the warnings.